### PR TITLE
feat: implement CharRefTokenizer

### DIFF
--- a/Sources/HTMLEntities/namedChars.swift
+++ b/Sources/HTMLEntities/namedChars.swift
@@ -2231,3 +2231,17 @@ public let namedChars: [String: (Unicode.Scalar, Unicode.Scalar)] = [
     "yen": ("\u{A5}", "\0"),
     "yuml": ("\u{FF}", "\0"),
 ]
+
+// FIXME: This process should be done at compile-time, not runtime.
+public let processedNamedChars: [String: (Unicode.Scalar, Unicode.Scalar)] = {
+    var namedChars = namedChars
+    for key in namedChars.keys {
+        for i in 1..<key.count {
+            let k = String(key.prefix(i))
+            if !namedChars.keys.contains(k) {
+                namedChars[k] = ("\0", "\0")
+            }
+        }
+    }
+    return namedChars
+}()

--- a/Sources/Tokenizer/CharRefTokenizer.swift
+++ b/Sources/Tokenizer/CharRefTokenizer.swift
@@ -134,7 +134,8 @@ struct CharRefTokenizer {
                 return .progress
             case _:
                 tokenizer.emitError(.absenceDigits)
-                return .done(["&", "#", uppercase ? "X" : "x"])
+                input.prepend(contentsOf: uppercase ? "#X" : "#x")
+                return .doneNone
             }
         case .decimalStart:
             switch tokenizer.peek(input)?.firstScalar {
@@ -143,7 +144,8 @@ struct CharRefTokenizer {
                 return .progress
             case _:
                 tokenizer.emitError(.absenceDigits)
-                return .done(["&", "#"])
+                input.prepend("#")
+                return .doneNone
             }
         case .hexadecimal:
             if let firstScalar = tokenizer.peek(input)?.firstScalar {

--- a/Sources/TokenizerMacros/Macros.swift
+++ b/Sources/TokenizerMacros/Macros.swift
@@ -162,7 +162,7 @@ extension GoMacro: CodeItemMacro {
         case "goEmitNewForceQuirksDOCTYPEAndEOF":
             return ["self.createDOCTYPE()", "self.forceQuirks()", "self.emitDOCTYPE()", "self.emitEOF()", "return .suspend"]
         case "goConsumeCharRef":
-            return ["self.consumeCharRef()", "return .continue"]
+            return ["self.consumeCharRef(\(node.arguments))", "return .continue"]
         case let name:
             preconditionFailure("not supported: \(name)")
         }


### PR DESCRIPTION
## Description

I've implemented `CharRefTokenizer`.

## Benchmark Results

```console
$ swift package --package-path Benchmarks benchmark baseline compare main
warning: 'package-benchmark': Jemalloc disabled through environment variable.
Building for debugging...
[9/9] Emitting module BenchmarkBoilerplateGenerator
Build of product 'BenchmarkBoilerplateGenerator' complete! (1.32s)
Building for debugging...
[1/1] Write swift-version--FC39A71C9A0968F.txt
Build of product 'BenchmarkTool' complete! (2.12s)
Build complete!
Building BenchmarkTool in release mode...
Building benchmark targets in release mode for benchmark run...
Building MyBenchmark

==================
Running Benchmarks
==================

100% [------------------------------------------------------------] ETA: 00:00:00 | MyBenchmark:TokenizerBenchmark

===================================================
Comparing results between 'main' and 'Current_run'
===================================================

Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:
#1 SMP PREEMPT_DYNAMIC Sun Mar 24 19:44:17 UTC 2024

MyBenchmark
============================================================================================================================

----------------------------------------------------------------------------------------------------------------------------
TokenizerBenchmark metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      12 │      12 │      12 │      12 │      13 │      20 │      20 │      80 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      12 │      12 │      12 │      13 │      13 │      15 │      15 │      81 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │       0 │       0 │       1 │       0 │      -5 │      -5 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │      -8 │       0 │      25 │      25 │       1 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│          Throughput (# / s) (K)          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      82 │      82 │      81 │      81 │      79 │      49 │      49 │      80 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      82 │      81 │      81 │      79 │      79 │      65 │      65 │      81 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │      -1 │       0 │      -2 │       0 │      16 │      16 │       1 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │      -1 │       0 │      -2 │       0 │      33 │      33 │       1 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```