### PR TITLE
build: reduce dependencies

### DIFF
--- a/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
+++ b/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
@@ -1,5 +1,5 @@
 private import Benchmark
-private import Collections
+private import DequeModule
 private import Tokenizer
 
 private struct TestSink {}

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
             dependencies: [
                 "TokenizerMacros",
                 "HTMLEntities",
-                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "DequeModule", package: "swift-collections"),
             ],
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),

--- a/Sources/Tokenizer/CharRefTokenizer.swift
+++ b/Sources/Tokenizer/CharRefTokenizer.swift
@@ -1,4 +1,4 @@
-import Collections
+import DequeModule
 private import HTMLEntities
 
 private enum CharRefState {

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1,4 +1,4 @@
-public import Collections
+public import DequeModule
 
 @freestanding(codeItem) private macro go(emit: Character) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) private macro go(error: ParseError..., emit: Token...) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")

--- a/Tests/TokenizerTests/BasicHTMLTests.swift
+++ b/Tests/TokenizerTests/BasicHTMLTests.swift
@@ -1,4 +1,4 @@
-private import Collections
+private import DequeModule
 import Testing
 private import Tokenizer
 

--- a/Tests/TokenizerTests/HTML5LibTests.swift
+++ b/Tests/TokenizerTests/HTML5LibTests.swift
@@ -1,4 +1,4 @@
-private import Collections
+private import DequeModule
 private import Foundation
 import Testing
 private import Tokenizer


### PR DESCRIPTION
Zyphy depends on DequeModule, so it doesn't need the other modules.