### PR TITLE
refactor: refactor CharRefTokenizer

### DIFF
--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -42,9 +42,14 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
 
     private mutating func step(_ input: inout BufferQueue) -> ProcessResult {
         if var charRefTokenizer {
-            if let scalars = charRefTokenizer.tokenize(tokenizer: &self, input: &input) {
-                self.processCharRef(scalars)
-            }
+            repeat {
+                switch charRefTokenizer.step(tokenizer: &self, input: &input) {
+                case .continue: continue
+                case .doneChars(let s): self.processCharRef(s)
+                case .doneChar(let c): self.processCharRef(c)
+                }
+                break
+            } while true
             self.charRefTokenizer = nil
         }
 


### PR DESCRIPTION
## Comparing results between 'main' and 'Current_run'

```
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:
#1 SMP PREEMPT_DYNAMIC Wed Apr 24 00:11:34 UTC 2024
```
## MyBenchmark

### lipsum metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      16 │      16 │      16 │      16 │      16 │      17 │      17 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      17 │      17 │      17 │      18 │      18 │      19 │      19 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       1 │       1 │       1 │       2 │       2 │       2 │       2 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      -6 │      -6 │      -6 │     -12 │     -12 │     -12 │     -12 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### lipsum-zh metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    2274 │    2279 │    2284 │    2290 │    2296 │    2302 │    2303 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    2133 │    2136 │    2140 │    2144 │    2154 │    2306 │    2307 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -141 │    -143 │    -144 │    -146 │    -142 │       4 │       4 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       6 │       6 │       6 │       6 │       6 │       0 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### medium-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      67 │      67 │      67 │      67 │      67 │      67 │      67 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      62 │      62 │      62 │      62 │      63 │      66 │      67 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      -5 │      -5 │      -5 │      -5 │      -4 │      -1 │       0 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       7 │       7 │       7 │       7 │       6 │       1 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### small-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    6297 │    6341 │    6353 │    6373 │    6398 │    6676 │    6891 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    5904 │    5939 │    5968 │    6001 │    6377 │    6417 │    6417 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -393 │    -402 │    -385 │    -372 │     -21 │    -259 │    -474 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       6 │       6 │       6 │       6 │       0 │       4 │       7 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### strong metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      36 │      36 │      36 │      36 │      36 │      36 │      36 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      34 │      34 │      34 │      34 │      34 │      36 │      36 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      -2 │      -2 │      -2 │      -2 │      -2 │       0 │       0 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       6 │       6 │       6 │       6 │       6 │       0 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### tiny-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     528 │     532 │     533 │     534 │    1010 │    1024 │    1025 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     496 │     505 │     534 │     617 │     670 │     691 │     737 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -32 │     -27 │       1 │      83 │    -340 │    -333 │    -288 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       6 │       5 │       0 │     -16 │      34 │      33 │      28 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>