### PR TITLE
perf: avoid reallocations

### DIFF
--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1357,7 +1357,8 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
 
     @inline(__always)
     private mutating func createTempBuffer(with c: consuming Char) {
-        self.tempBuffer = [c]
+        self.tempBuffer.removeAll(keepingCapacity: true)
+        self.tempBuffer.append(c)
     }
 
     @inline(__always)
@@ -1368,12 +1369,13 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
     @inline(__always)
     private mutating func emitTempBuffer() {
         self.emit(ArraySlice(self.tempBuffer))
-        self.tempBuffer.removeAll()
+        self.tempBuffer.removeAll(keepingCapacity: true)
     }
 
     @inline(__always)
     private mutating func createComment(with c: consuming Char) {
-        self.currentComment = [c]
+        self.currentComment.removeAll(keepingCapacity: true)
+        self.currentComment.append(c)
     }
 
     @_disfavoredOverload
@@ -1400,16 +1402,18 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
 
     @inline(__always)
     private mutating func createStartTag(with c: consuming Char) {
-        self.currentTagName = [c]
+        self.currentTagName.removeAll(keepingCapacity: true)
+        self.currentTagName.append(c)
         self.currentTagKind = .start
-        self.currentAttrs.removeAll()
+        self.currentAttrs.removeAll(keepingCapacity: true)
     }
 
     @inline(__always)
     private mutating func createEndTag(with c: consuming Char) {
-        self.currentTagName = [c]
+        self.currentTagName.removeAll(keepingCapacity: true)
+        self.currentTagName.append(c)
         self.currentTagKind = .end
-        self.currentAttrs.removeAll()
+        self.currentAttrs.removeAll(keepingCapacity: true)
     }
 
     @inline(__always)
@@ -1420,7 +1424,7 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
     @inline(__always)
     private mutating func createAttr(with c: consuming Char) {
         self.pushAttr()
-        self.currentAttrName = [c]
+        self.currentAttrName.append(c)
     }
 
     @inline(__always)
@@ -1446,8 +1450,8 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
         } else {
             self.currentAttrs[self.currentAttrName] = self.currentAttrValue
         }
-        self.currentAttrName.removeAll()
-        self.currentAttrValue.removeAll()
+        self.currentAttrName.removeAll(keepingCapacity: true)
+        self.currentAttrValue.removeAll(keepingCapacity: true)
     }
 
     @inline(__always)

--- a/Sources/TokenizerMacros/GoMacro.swift
+++ b/Sources/TokenizerMacros/GoMacro.swift
@@ -56,7 +56,7 @@ extension GoMacro: CodeItemMacro {
                     argList = .init(argList.dropFirst())
                 case "clearComment":
                     precondition(argList.count == 1)
-                    items += ["self.currentComment.removeAll()", "self.go(to: \(arg.expression))", "return .continue"]
+                    items += ["self.currentComment.removeAll(keepingCapacity: true)", "self.go(to: \(arg.expression))", "return .continue"]
                     break loop
                 case "emitComment":
                     precondition(argList.count == 1)
@@ -131,7 +131,7 @@ extension GoMacro: CodeItemMacro {
                     items += ["self.appendTempBuffer(\(arg.expression))"]
                     argList = .init(argList.dropFirst())
                 case "clearTemp":
-                    items += ["self.tempBuffer.removeAll()", "self.go(to: \(arg.expression))", "return .continue"]
+                    items += ["self.tempBuffer.removeAll(keepingCapacity: true)", "self.go(to: \(arg.expression))", "return .continue"]
                     break loop
                 case "emitTempAndReconsume":
                     precondition(argList.count == 2)


### PR DESCRIPTION
This improves performance of `Tokenizer` by reducing reallocations.

## Comparing results between 'main' and 'Current_run'

```
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:
#1 SMP PREEMPT_DYNAMIC Tue Apr 30 02:30:34 UTC 2024
```
## MyBenchmark

### lipsum metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      17 │      17 │      17 │      17 │      18 │      19 │      19 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      17 │      17 │      17 │      17 │      18 │      18 │      18 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │       0 │       0 │       0 │       0 │      -1 │      -1 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       0 │       0 │       5 │       5 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### lipsum-zh metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    2135 │    2150 │    2216 │    2226 │    2294 │    2312 │    2317 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    2117 │    2122 │    2126 │    2130 │    2140 │    2286 │    2288 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -18 │     -28 │     -90 │     -96 │    -154 │     -26 │     -29 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       1 │       1 │       4 │       4 │       7 │       1 │       1 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### medium-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      62 │      62 │      62 │      62 │      65 │      66 │      66 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      50 │      50 │      50 │      50 │      51 │      54 │      54 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -12 │     -12 │     -12 │     -12 │     -14 │     -12 │     -12 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      19 │      19 │      19 │      19 │      22 │      18 │      18 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### small-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    5903 │    5927 │    5960 │    6078 │    6140 │    6291 │    6369 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    5372 │    5390 │    5411 │    5427 │    5435 │    5575 │    5575 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │    -531 │    -537 │    -549 │    -651 │    -705 │    -716 │    -794 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       9 │       9 │       9 │      11 │      11 │      11 │      12 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### strong metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      34 │      34 │      34 │      34 │      36 │      37 │      41 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      23 │      23 │      23 │      23 │      23 │      24 │      24 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -11 │     -11 │     -11 │     -11 │     -13 │     -13 │     -17 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      32 │      32 │      32 │      32 │      36 │      35 │      41 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### tiny-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     496 │     517 │     534 │     616 │     672 │     730 │     733 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     533 │     543 │     575 │     623 │     665 │     721 │     721 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      37 │      26 │      41 │       7 │      -7 │      -9 │     -12 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      -7 │      -5 │      -8 │      -1 │       1 │       1 │       2 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>
