### PR TITLE
feat: `Str` conforms to `ExpressibleByStringLiteral`

### DIFF
--- a/Sources/Tokenizer/Str.swift
+++ b/Sources/Tokenizer/Str.swift
@@ -2,12 +2,22 @@ public typealias Str = [Char]
 public typealias StrSlice = ArraySlice<Char>
 public typealias Char = Unicode.Scalar
 
-extension Str {
-    static func == (lhs: Self, rhs: String) -> Bool {
-        guard lhs.count == rhs.count else { return false }
-        for (l, r) in zip(lhs, rhs.unicodeScalars) {
-            guard l == r else { return false }
-        }
-        return true
+extension Str: @retroactive ExpressibleByStringLiteral {
+    @inlinable public init(stringLiteral value: StringLiteralType) {
+        self = .init(value.unicodeScalars)
     }
 }
+
+extension Str: @retroactive ExpressibleByUnicodeScalarLiteral {
+    @inlinable public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        self = .init(value.unicodeScalars)
+    }
+}
+
+extension Str: @retroactive ExpressibleByExtendedGraphemeClusterLiteral {
+    @inlinable public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        self = .init(value.unicodeScalars)
+    }
+}
+
+extension Str: @retroactive ExpressibleByStringInterpolation {}

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1270,12 +1270,12 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
     @inline(__always)
     private mutating func startsExact(
         _ input: inout BufferQueue,
-        with pattern: consuming some StringProtocol
+        with pattern: consuming Str
     ) -> Bool? {
         guard !input.buffers.isEmpty else { return nil }
         var bufIndex = 0
         var i = 0
-        for pc in pattern.unicodeScalars {
+        for pc in pattern {
             guard bufIndex < input.buffers.count else { return nil }
             let buf = input.buffers[bufIndex]
             let c = buf[buf.startIndex + i]
@@ -1296,12 +1296,12 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
     @inline(__always)
     private mutating func starts(
         _ input: inout BufferQueue,
-        with pattern: consuming some StringProtocol
+        with pattern: consuming Str
     ) -> Bool? {
         guard !input.buffers.isEmpty else { return nil }
         var bufIndex = 0
         var i = 0
-        for pc in pattern.unicodeScalars {
+        for pc in pattern {
             guard bufIndex < input.buffers.count else { return nil }
             let buf = input.buffers[bufIndex]
             let c = buf[buf.startIndex + i]


### PR DESCRIPTION
## Comparing results between 'main' and 'Current_run'

```
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:
#1 SMP PREEMPT_DYNAMIC Wed May  8 18:05:42 UTC 2024
```
## MyBenchmark

### lipsum metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      17 │      17 │      17 │      17 │      17 │      18 │      18 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      15 │      15 │      16 │      16 │      16 │      16 │      16 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      -2 │      -2 │      -1 │      -1 │      -1 │      -2 │      -2 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      12 │      12 │       6 │       6 │       6 │      11 │      11 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### lipsum-zh metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    2114 │    2126 │    2130 │    2138 │    2206 │    2300 │    2300 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    2110 │    2116 │    2120 │    2122 │    2130 │    2374 │    2456 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      -4 │     -10 │     -10 │     -16 │     -76 │      74 │     156 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       1 │       3 │      -3 │      -7 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### medium-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      50 │      50 │      50 │      50 │      51 │      53 │      53 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      50 │      50 │      50 │      50 │      50 │      53 │      53 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │       0 │       0 │       0 │      -1 │       0 │       0 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       0 │       2 │       0 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### small-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    5334 │    5345 │    5362 │    5382 │    5415 │    5560 │    5560 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    5338 │    5358 │    5382 │    5390 │    5411 │    5579 │    5608 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       4 │      13 │      20 │       8 │      -4 │      19 │      48 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       0 │       0 │       0 │      -1 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### strong metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      22 │      23 │      23 │      23 │      23 │      24 │      24 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      24 │      24 │      24 │      24 │      24 │      25 │      25 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       2 │       1 │       1 │       1 │       1 │       1 │       1 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      -9 │      -4 │      -4 │      -4 │      -4 │      -4 │      -4 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### tiny-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     528 │     531 │     568 │     614 │     657 │     713 │     715 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     528 │     530 │     533 │     543 │     569 │     573 │     573 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │      -1 │     -35 │     -71 │     -88 │    -140 │    -142 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       6 │      12 │      13 │      20 │      20 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

