### PR TITLE
perf: avoid reallocations

### DIFF
--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1502,9 +1502,13 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
         }
     }
 
+    // swift-format-ignore: NeverForceUnwrap
     @inline(__always)
     private mutating func clearPublicID() {
-        self.currentDOCTYPE.publicID = []
+        switch self.currentDOCTYPE.publicID {
+        case .some: self.currentDOCTYPE.publicID!.removeAll(keepingCapacity: true)
+        case .none: self.currentDOCTYPE.publicID = []
+        }
     }
 
     @inline(__always)
@@ -1515,9 +1519,13 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
         }
     }
 
+    // swift-format-ignore: NeverForceUnwrap
     @inline(__always)
     private mutating func clearSystemID() {
-        self.currentDOCTYPE.systemID = []
+        switch self.currentDOCTYPE.systemID {
+        case .some: self.currentDOCTYPE.systemID!.removeAll(keepingCapacity: true)
+        case .none: self.currentDOCTYPE.systemID = []
+        }
     }
 
     @inline(__always)


### PR DESCRIPTION
## Comparing results between 'main' and 'Current_run'

```
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:
#1 SMP PREEMPT_DYNAMIC Fri May 17 17:22:13 UTC 2024
```
## MyBenchmark

### lipsum metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      15 │      16 │      16 │      16 │      17 │      17 │      17 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      15 │      15 │      15 │      16 │      16 │      16 │      16 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │      -1 │      -1 │       0 │      -1 │      -1 │      -1 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       6 │       6 │       0 │       6 │       6 │       6 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### lipsum-zh metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    2085 │    2093 │    2095 │    2101 │    2183 │    2431 │    2431 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    2095 │    2103 │    2107 │    2116 │    2120 │    2254 │    2254 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      10 │      10 │      12 │      15 │     -63 │    -177 │    -177 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │      -1 │      -1 │       3 │       7 │       7 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### medium-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      49 │      49 │      49 │      49 │      50 │      52 │      53 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      49 │      49 │      49 │      49 │      50 │      53 │      53 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │       0 │       0 │       0 │       0 │       1 │       0 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       0 │       0 │      -2 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### small-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    5272 │    5288 │    5321 │    5468 │    5505 │    5659 │    5659 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    5252 │    5272 │    5296 │    5300 │    5308 │    5456 │    5514 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -20 │     -16 │     -25 │    -168 │    -197 │    -203 │    -145 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       3 │       4 │       4 │       3 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### strong metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      22 │      22 │      22 │      22 │      23 │      24 │      24 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      22 │      22 │      22 │      22 │      22 │      24 │      24 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │       0 │       0 │       0 │       0 │      -1 │       0 │       0 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │       0 │       0 │       0 │       0 │       4 │       0 │       0 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>

### tiny-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

```
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     516 │     520 │     538 │     559 │    1048 │    1115 │    1116 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     540 │     563 │     655 │     768 │     859 │    1058 │    1061 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      24 │      43 │     117 │     209 │    -189 │     -57 │     -55 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      -5 │      -8 │     -22 │     -37 │      18 │       5 │       5 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

```
<p>
</details>
