### PR TITLE
perf: improve performance of `BufferQueue.pop`

### DIFF
--- a/Sources/Tokenizer/BufferQueue.swift
+++ b/Sources/Tokenizer/BufferQueue.swift
@@ -24,16 +24,14 @@ public struct BufferQueue: ~Copyable, Sendable {
         return self.buffers[0].popFirst()
     }
 
+    @inline(__always)
     mutating func pop(except s: consuming SmallCharSet) -> PopResult? {
         guard !self.buffers.isEmpty else { return nil }
         defer { if self.buffers[0].isEmpty { self.buffers.removeFirst() } }
-        let others = self.buffers[0].prefix { $0.value >= 64 || !s.contains($0) }
-        self.buffers[0].removeFirst(others.count)
-        return if others.isEmpty {
-            self.buffers[0].popFirst().map(PopResult.known)
-        } else {
-            .others(others)
-        }
+        let count = (self.buffers[0].firstIndex { $0.value < 64 && s.contains($0) } ?? self.buffers[0].endIndex) - self.buffers[0].startIndex
+        guard count > 0 else { return self.buffers[0].popFirst().map(PopResult.known) }
+        defer { self.buffers[0].removeFirst(count) }
+        return .others(self.buffers[0].prefix(count))
     }
 
     mutating func removeFirst() {


### PR DESCRIPTION
refs #61

```
===================================================                                                                                                                                        
Comparing results between 'main' and 'Current_run'                                                                                                                                         
===================================================                                                                                                                                        
                                                                                                                                                                                           
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:                                                                                                      
#1 SMP PREEMPT_DYNAMIC Fri May 17 17:22:13 UTC 2024                                                                                                                                        
                                                                                                                                                                                           
MyBenchmark                                                                                                                                                                                
============================================================================================================================                                                               
                                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------                                                               
lipsum metrics                                                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------                                                               
                                                                                                                                                                                           
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕                                                               
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │                                                               
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡                                                               
│                   main                   │      17 │      17 │      17 │      17 │      18 │      18 │      18 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│               Current_run                │      14 │      14 │      14 │      14 │      15 │      15 │      15 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│                    Δ                     │      -3 │      -3 │      -3 │      -3 │      -3 │      -3 │      -3 │       0 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│              Improvement %               │      18 │      18 │      18 │      18 │      17 │      17 │      17 │       0 │                                                               
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛                                                               
                                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------                                                               
lipsum-zh metrics                                                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------                                                               
                                                                                                                                                                                           
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕                                                               
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │                                                               
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡                                                               
│                   main                   │    2080 │    2095 │    2161 │    2236 │    2245 │    2476 │    2589 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│               Current_run                │    1559 │    1570 │    1576 │    1620 │    1678 │    1814 │    1818 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│                    Δ                     │    -521 │    -525 │    -585 │    -616 │    -567 │    -662 │    -771 │       0 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│              Improvement %               │      25 │      25 │      27 │      28 │      25 │      27 │      30 │       0 │                                                               
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛                                                               
                                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------                                                               
medium-fragment metrics                                                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------                                                               
                                                                                                                                                                                           
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕                                                               
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │                                                               
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡                                                               
│                   main                   │      49 │      49 │      49 │      49 │      50 │      53 │      53 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│               Current_run                │      44 │      44 │      44 │      44 │      44 │      47 │      47 │     100 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│                    Δ                     │      -5 │      -5 │      -5 │      -5 │      -6 │      -6 │      -6 │       0 │                                                               
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                                               
│              Improvement %               │      10 │      10 │      10 │      10 │      12 │      11 │      11 │       0 │                                                               
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛              

----------------------------------------------------------------------------------------------------------------------------                                                               
small-fragment metrics                                                                                                                                                                     
----------------------------------------------------------------------------------------------------------------------------                                                               
                                                                                                                                                                                           
╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕                                                               
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │                                             
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │    5259 │    5280 │    5304 │    5329 │    5665 │    5713 │    5713 │     100 │                                             
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │    4590 │    4604 │    4637 │    4755 │    4936 │    4952 │    5293 │     100 │                                             
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                             
│                    Δ                     │    -669 │    -676 │    -667 │    -574 │    -729 │    -761 │    -420 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤                                             
│              Improvement %               │      13 │      13 │      13 │      11 │      13 │      13 │       7 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛                                             

----------------------------------------------------------------------------------------------------------------------------
strong metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (μs) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │      22 │      22 │      22 │      22 │      22 │      24 │      24 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │      19 │      19 │      19 │      19 │      20 │      21 │      21 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │      -3 │      -3 │      -3 │      -3 │      -2 │      -3 │      -3 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      14 │      14 │      14 │      14 │       9 │      12 │      12 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

----------------------------------------------------------------------------------------------------------------------------
tiny-fragment metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│         Time (wall clock) (ns) *         │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│                   main                   │     518 │     537 │     557 │     603 │     645 │     700 │     701 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│               Current_run                │     452 │     470 │     489 │     528 │     564 │     611 │     614 │     100 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│                    Δ                     │     -66 │     -67 │     -68 │     -75 │     -81 │     -89 │     -87 │       0 │
├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│              Improvement %               │      13 │      12 │      12 │      12 │      13 │      13 │      12 │       0 │
╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```