### PR TITLE
test: remove Bundle workarounds

### DIFF
--- a/Benchmarks/Benchmarks/MyBenchmark/Bundle+Sendable.swift
+++ b/Benchmarks/Benchmarks/MyBenchmark/Bundle+Sendable.swift
@@ -1,4 +1,0 @@
-private import Foundation
-
-// FIXME: This is a workaround for "error: static property 'module' is not concurrency-safe because non-'Sendable' type 'Bundle' may have shared mutable state"
-extension Bundle: @retroactive @unchecked Sendable {}

--- a/Tests/HTMLEntitiesTests/Bundle+Sendable.swift
+++ b/Tests/HTMLEntitiesTests/Bundle+Sendable.swift
@@ -1,4 +1,0 @@
-private import Foundation
-
-// FIXME: This is a workaround for "error: static property 'module' is not concurrency-safe because non-'Sendable' type 'Bundle' may have shared mutable state"
-extension Bundle: @retroactive @unchecked Sendable {}

--- a/Tests/TokenizerTests/Bundle+Sendable.swift
+++ b/Tests/TokenizerTests/Bundle+Sendable.swift
@@ -1,4 +1,0 @@
-private import Foundation
-
-// FIXME: This is a workaround for "error: static property 'module' is not concurrency-safe because non-'Sendable' type 'Bundle' may have shared mutable state"
-extension Bundle: @retroactive @unchecked Sendable {}


### PR DESCRIPTION
`Bundle` has been `Sendable` since https://github.com/apple/swift-corelibs-foundation/pull/4963, so we no longer need workarounds.