### PR TITLE
chore: refactor swift language versions

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -30,5 +30,5 @@ let package = Package(
             ]
         )
     ],
-    swiftLanguageVersions: [.version("6")]
+    swiftLanguageVersions: [.v6]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -127,5 +127,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageVersions: [.version("6")]
+    swiftLanguageVersions: [.v6]
 )


### PR DESCRIPTION
The latest Swift 6.0 toolchain can recognize `v6` as a known language version, so I'm going to use it.
