### PR TITLE
ci: avoid building twice

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,8 +19,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       - run: swift --version
-      - run: swift build
-      - run: swift test --disable-xctest --enable-code-coverage --no-parallel
+      - run: swift build --build-tests --disable-xctest --enable-code-coverage
+      - run: swift test --skip-build --disable-xctest --enable-code-coverage --no-parallel
       # FIXME: `grep -v 184467440737095` is a workaround for octocov parse error
       - run: llvm-cov export --format=lcov .build/debug/zyphyPackageTests.swift-testing --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests|TokenizerMacros" | grep -v 184467440737095 > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1


### PR DESCRIPTION
Normally, both `swift build` and `swift test` build source code. This is a waste of time. To resolve it, I've changed the CI scripts so that only `swift build` builds source code and `swift test` just runs a test executable.

- before: 4m 49s https://github.com/kkebo/zyphy/actions/runs/9353807411
- after: 2m 35s https://github.com/kkebo/zyphy/actions/runs/9465468770

references:

- https://github.com/apple/swift-package-manager/pull/7565