### PR TITLE
build: update swift-syntax to swiftlang/swift-syntax

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -67,7 +67,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6ade4dbbfcdcb562e5426e9146b5e10f87e080cf825177bce803c01645d35186",
+  "originHash" : "a7602d1b917fe51152a9de7e9872bc386b69dcdb4807d41ad3596a647cda4303",
   "pins" : [
     {
       "identity" : "swift-collections",
@@ -13,10 +13,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "74c759fe021b87849501af3808ef24fcba8dfff3",
-        "version" : "600.0.0-prerelease-2024-06-04"
+        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
+        "version" : "600.0.0-prerelease-2024-06-12"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "TreeConstructor", targets: ["TreeConstructor"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
         .package(url: "https://github.com/apple/swift-testing", from: "0.9.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     ],


### PR DESCRIPTION
apple/swift-syntax has been moved to swiftlang/swift-syntax. So I'm updating its URLs in Package.swift and Package.resolved.
