### PR TITLE
fix: make TreeConstructor's TokenSink conformance public

### DIFF
--- a/Sources/TreeConstructor/TreeConstructor.swift
+++ b/Sources/TreeConstructor/TreeConstructor.swift
@@ -1,4 +1,4 @@
-import Tokenizer
+public import Tokenizer
 
 public struct TreeConstructor: ~Copyable {
     private var mode: InsertionMode
@@ -9,7 +9,7 @@ public struct TreeConstructor: ~Copyable {
 }
 
 extension TreeConstructor: TokenSink {
-    mutating func process(_ token: consuming Token) {
+    public mutating func process(_ token: consuming Token) {
         switch self.mode {
         case .initial:
             switch token {


### PR DESCRIPTION
fixes #95