### PR TITLE
ci: fix CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,10 +19,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       - run: swift --version
-      - run: swift build --build-tests --enable-code-coverage
+      - run: swift build --build-tests --disable-xctest --enable-code-coverage
       - run: swift test --skip-build --disable-xctest --enable-code-coverage
       # FIXME: `grep -v 184467440737095` is a workaround for octocov parse error
-      - run: llvm-cov export --format=lcov .build/debug/zyphyPackageTests.swift-testing --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests|TokenizerMacros" | grep -v 184467440737095 > coverage_report.lcov
+      - run: llvm-cov export --format=lcov .build/debug/zyphyPackageTests.xctest --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests|TokenizerMacros" | grep -v 184467440737095 > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
zyphyPackageTests.xctest and zyphyPackageTests.swift-testing are now merged into zyphyPackageTests.xctest in the latest toolchain.