### PR TITLE
fix: fix compiler warning

### DIFF
--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1,4 +1,4 @@
-public import Str
+private import Str
 
 public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
     public var sink: Sink


### PR DESCRIPTION
I have fixed the following warning.

```
/home/kebo/zyphy/Sources/Tokenizer/Tokenizer.swift:1:8: warning: public import of 'Str' was not used in public declarations or inlinable code
   1 | public import Str
     |        `- warning: public import of 'Str' was not used in public declarations or inlinable code
   2 | 
   3 | public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
```