### PR TITLE
perf(Tokenizer): improve performance

### DIFF
--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1463,7 +1463,6 @@ public struct Tokenizer<Sink: ~Copyable & TokenSink>: ~Copyable {
         self.currentAttrValue.removeAll(keepingCapacity: true)
     }
 
-    @inline(__always)
     private mutating func emitTag(selfClosing: Bool = false) {
         self.pushAttr()
 


### PR DESCRIPTION
## Comparing results between 'main' and 'Current_run'                                                                                                                                    
                                                                                                                                                                                         
```                                                                                                                                                                                      
Host 'Brown-rhinoceros-beetle' with 8 'aarch64' processors with 7 GB memory, running:                                                                                                    
#1 SMP PREEMPT_DYNAMIC Sat Aug  3 22:26:24 UTC 2024                                                                                                                                      
```                                                                                                                                                                                      
## MyBenchmark                                                                                                                                                                           
                                                                                                                                                                                         
### lipsum metrics                                                                                                                                                                       
                                                                                                                                                                                         
<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>                                                                               
<p>                                                                                                                                                                                      
                                                                                                                                                                                         
|         Time (wall clock) (μs) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |                                                             
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|                                                             
|                   main                   |      14 |      14 |      14 |      14 |      14 |      15 |      15 |     100 |                                                             
|               Current_run                |      13 |      14 |      14 |      14 |      14 |      15 |      15 |     100 |                                                             
|                    Δ                     |      -1 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |                                                             
|              Improvement %               |       7 |       0 |       0 |       0 |       0 |       0 |       0 |       0 |                                                             
                                                                                                                                                                                         
<p>                                                                                                                                                                                      
</details>                                                                                                                                                                               
                                                                                                                                                                                         
### lipsum-zh metrics                                                                                                                                                                    
                                                                                                                                                                                         
<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>                                                                               
<p>                                                                                                                                                                                      
                                                                                                                                                                                         
|         Time (wall clock) (ns) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |                                                             
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|                                                             
|                   main                   |    1550 |    1554 |    1558 |    1564 |    1585 |    1798 |    1799 |     100 |                                                             
|               Current_run                |    1548 |    1553 |    1559 |    1564 |    1572 |    1670 |    1673 |     100 |                                                             
|                    Δ                     |      -2 |      -1 |       1 |       0 |     -13 |    -128 |    -126 |       0 |                                                             
|              Improvement %               |       0 |       0 |       0 |       0 |       1 |       7 |       7 |       0 |                                                             
                                                                                                                                                                                         
<p>                                                                                                                                                                                      
</details>                                                                                                                                                                               
                                                                                                                                                                                         
### medium-fragment metrics                                                                                                                                                              
                                                                                                                                                                                         
<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>                                                                               
<p>                                                                                                                                                                                      
                                                                                                                                                                                         
|         Time (wall clock) (μs) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |                                                             
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|                                                             
|                   main                   |      41 |      41 |      41 |      41 |      41 |      44 |      44 |     100 |                                                             
|               Current_run                |      41 |      41 |      41 |      41 |      41 |      43 |      43 |     100 |                                                             
|                    Δ                     |       0 |       0 |       0 |       0 |       0 |      -1 |      -1 |       0 |                                                             
|              Improvement %               |       0 |       0 |       0 |       0 |       0 |       2 |       2 |       0 |                                                             
                                                                                                                                                                                         
<p>                                                                                                                                                                                      
</details>             

### small-fragment metrics                                                                                                                                                               
                                                                                                                                                                                         
<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>                                                                               
<p>                                                                                                                                                                                      
                                                                                                                                                                                         
|         Time (wall clock) (ns) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |                                                             
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|                                                             
|                   main                   |    4478 |    4485 |    4493 |    4641 |    4649 |    4657 |    4688 |     100 |                                                             
|               Current_run                |    4506 |    4514 |    4522 |    4669 |    4674 |    4682 |    4682 |     100 |                                                             
|                    Δ                     |      28 |      29 |      29 |      28 |      25 |      25 |      -6 |       0 |                                                             
|              Improvement %               |      -1 |      -1 |      -1 |      -1 |      -1 |      -1 |       0 |       0 |                                          

<p>
</details>

### strong metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (μs) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   main                   |      19 |      19 |      19 |      19 |      20 |      21 |      21 |     100 |
|               Current_run                |      19 |      19 |      19 |      19 |      19 |      20 |      20 |     100 |
|                    Δ                     |       0 |       0 |       0 |       0 |      -1 |      -1 |      -1 |       0 |
|              Improvement %               |       0 |       0 |       0 |       0 |       5 |       5 |       5 |       0 |

<p>
</details>

### tiny-fragment metrics

<details><summary>Time (wall clock): results within specified thresholds, fold down for details.</summary>
<p>

|         Time (wall clock) (ns) *         |      p0 |     p25 |     p50 |     p75 |     p90 |     p99 |    p100 | Samples |
|:----------------------------------------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|--------:|
|                   main                   |     488 |     529 |     614 |     672 |     675 |     903 |     903 |     100 |
|               Current_run                |     452 |     456 |     458 |     487 |     911 |     976 |     977 |     100 |
|                    Δ                     |     -36 |     -73 |    -156 |    -185 |     236 |      73 |      74 |       0 |
|              Improvement %               |       7 |      14 |      25 |      28 |     -35 |      -8 |      -8 |       0 |

<p>
</details>