### PR TITLE
build: remove CMO flags from library targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,6 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
                 .enableExperimentalFeature("CodeItemMacros"),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
@@ -47,7 +46,6 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
             ]


### PR DESCRIPTION
[swift-homomorphic-encryption](https://github.com/apple/swift-homomorphic-encryption/blob/main/Package.swift) enables CMO only on executable or benchmark targets, not on library targets. I mimics it.