### PR TITLE
build: use built-in swift-testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,17 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
-        "version" : "600.0.0-prerelease-2024-08-14"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing",
-      "state" : {
-        "revision" : "c55848b2aa4b29a4df542b235dfdd792a6fbe341",
-        "version" : "0.12.0"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
-        .package(url: "https://github.com/swiftlang/swift-testing", from: "0.9.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     ],
     targets: [
@@ -85,7 +84,6 @@ let package = Package(
             dependencies: [
                 "TokenizerMacros",
                 "Tokenizer",
-                .product(name: "Testing", package: "swift-testing"),
             ],
             exclude: [
                 "Resources/html5lib-tests/encoding",
@@ -122,8 +120,7 @@ let package = Package(
         .testTarget(
             name: "HTMLEntitiesTests",
             dependencies: [
-                "HTMLEntities",
-                .product(name: "Testing", package: "swift-testing"),
+                "HTMLEntities"
             ],
             resources: [
                 .process("Resources")


### PR DESCRIPTION
swift-testing is now built into the toolchain, so we don't need to use the external dependencies.