### PR TITLE
ci: rename build-linux to test

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["main"]
 jobs:
-  build-linux:
+  test:
     runs-on: ubuntu-latest
     container: swiftlang/swift:nightly-6.0-jammy
     steps:


### PR DESCRIPTION
The CI job `build-linux` not only runs `swift build`, but also `swift test`.