### PR TITLE
ci: remove `set +e` from `swift package benchmark baseline compare`

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -81,7 +81,6 @@ jobs:
       - name: swift package benchmark baseline compare
         id: compare
         run: |
-          set +e
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
           swift package --package-path Benchmarks benchmark baseline compare main pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`swift package benchmark baseline check` may exit with status code 4 even if there are no performance regressions, but `swift package benchmark baseline compare` always returns status code 0 or 1.