### PR TITLE
ci: fix CI on main branch

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,6 +46,7 @@ jobs:
           SUMMARY: ${{ steps.summary.outputs.SUMMARY }}
         run: echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
       - name: Comment PR
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: ${{ steps.summary.outputs.SUMMARY }}


### PR DESCRIPTION
The “Comment PR” step of the test job is executed only when it is not on the main branch, and only the job summary is created when it is on the main branch.