### PR TITLE
ci: add `--parallel` to swift-format

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -56,7 +56,7 @@ jobs:
     container: swiftlang/swift:nightly-6.0-jammy
     steps:
       - uses: actions/checkout@v4
-      - run: swift format lint -rs .
+      - run: swift format lint -rsp .
   benchmark:
     if: ${{ github.ref != 'refs/heads/main' }}
     needs: test


### PR DESCRIPTION
This change makes the CI job faster.