### PR TITLE
ci: enable parallel test

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-spm-
       - run: swift --version
       - run: swift build --build-tests --disable-xctest --enable-code-coverage
-      - run: swift test --skip-build --disable-xctest --enable-code-coverage
+      - run: swift test --skip-build --disable-xctest --enable-code-coverage --parallel
       - name: llvm-cov report
         id: report
         run: |


### PR DESCRIPTION
I added `--parallel` to `swift test`. This improves performance of test execution.
I would like to enable it if it doesn't affect code coverage.