### PR TITLE
revert: build: bump swift-tools-version to 6.1

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import CompilerPluginSupport
 import PackageDescription


### PR DESCRIPTION
This fixes [the dependabot error](https://github.com/kkebo/zyphy/actions/runs/12355959747/job/34480768869).