### PR TITLE
build: remove explicit language mode specifications

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -29,6 +29,5 @@ let package = Package(
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]
         )
-    ],
-    swiftLanguageModes: [.v6]
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -137,6 +137,5 @@ let package = Package(
                 .enableUpcomingFeature("MemberImportVisibility"),
             ]
         ),
-    ],
-    swiftLanguageModes: [.v6]
+    ]
 )


### PR DESCRIPTION
Swift tools version 6 uses Swift 6 language mode by default, so I don't need to specify language mode explicitly.