### PR TITLE
chore: add `.swift-version`

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,0 +1,1 @@
+6.1-snapshot

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Zyphy is (or will be) a fast web browser engine written in Swift.
 You can easily install the toolchain using [Swiftly](https://www.swift.org/install/).
 
 ```shell
-swiftly install 6.1-snapshot
-swiftly use 6.1-snapshot
+swiftly install
 ```
 
 ## Building


### PR DESCRIPTION
swiftly will install and use the toolchain written in `.swift-version`.