### PR TITLE
Swift 6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-6.1-noble
+    container: swiftlang/swift:nightly-6.2-noble
     outputs:
       SUMMARY: ${{ steps.summary.outputs.SUMMARY }}
     steps:
@@ -60,7 +60,7 @@ jobs:
           comment-tag: coverage
   lint:
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-6.1-noble
+    container: swiftlang/swift:nightly-6.2-noble
     steps:
       - uses: actions/checkout@v4
       - run: swift format lint -rsp .
@@ -68,7 +68,7 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-6.1-noble
+    container: swiftlang/swift:nightly-6.2-noble
     outputs:
       SUMMARY: ${{ steps.summary.outputs.SUMMARY }}
     steps:

--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-6.1-snapshot
+6.2-snapshot

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import CompilerPluginSupport
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Zyphy is (or will be) a fast web browser engine written in Swift.
 ## Prerequisites
 
 - [Swiftly](https://www.swift.org/install/)
-- Swift 6.1 development snapshot toolchain: Just run `swiftly install` after installing Swiftly
+- Swift 6.2 development snapshot toolchain: Just run `swiftly install` after installing Swiftly
   - We can't use a stable toolchain yet because Zyphy is using experimental [code item macros](https://github.com/swiftlang/swift-evolution/blob/main/visions/macros.md#macro-roles).
 
 ## Building


### PR DESCRIPTION
Swift 6.2 snapshot toolchains have been available recently. So I updated the toolchain version from 6.1-snapshot to 6.2-snapshot.