### PR TITLE
style: add trailing commas (SE-0439)

### DIFF
--- a/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
+++ b/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
@@ -33,7 +33,7 @@ let benchmarks = {
         warmupIterations: 10,
         scalingFactor: .kilo,
         maxDuration: .seconds(60),
-        maxIterations: 100
+        maxIterations: 100,
     )
 
     runBench("lipsum", configuration: conf)

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             ],
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
-            ]
+            ],
         )
-    ]
+    ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .target(
             name: "TreeConstructor",
@@ -53,7 +53,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .macro(
             name: "TokenizerMacros",
@@ -66,7 +66,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .target(
             name: "HTMLEntities",
@@ -77,7 +77,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .target(
             name: "Str",
@@ -86,7 +86,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .testTarget(
             name: "TokenizerTests",
@@ -126,7 +126,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .testTarget(
             name: "HTMLEntitiesTests",
@@ -141,7 +141,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
         .testTarget(
             name: "TreeConstructorTests",
@@ -153,7 +153,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
-            ]
+            ],
         ),
-    ]
+    ],
 )

--- a/Sources/Tokenizer/DOCTYPE.swift
+++ b/Sources/Tokenizer/DOCTYPE.swift
@@ -10,7 +10,7 @@ public struct DOCTYPE: ~Copyable, Sendable {
         name: consuming Str? = nil,
         publicID: consuming Str? = nil,
         systemID: consuming Str? = nil,
-        forceQuirks: Bool = false
+        forceQuirks: Bool = false,
     ) {
         self.name = name
         self.publicID = publicID
@@ -24,7 +24,7 @@ public struct DOCTYPE: ~Copyable, Sendable {
             name: self.name,
             publicID: self.publicID,
             systemID: self.systemID,
-            forceQuirks: self.forceQuirks
+            forceQuirks: self.forceQuirks,
         )
     }
 }

--- a/Sources/Tokenizer/Tag.swift
+++ b/Sources/Tokenizer/Tag.swift
@@ -10,7 +10,7 @@ public struct Tag: ~Copyable, Sendable {
         name: consuming Str,
         kind: consuming TagKind,
         attrs: consuming [Str: Str] = [:],
-        selfClosing: Bool = false
+        selfClosing: Bool = false,
     ) {
         self.name = name
         self.kind = kind

--- a/Sources/TokenizerMacros/GoMacro.swift
+++ b/Sources/TokenizerMacros/GoMacro.swift
@@ -7,7 +7,7 @@ struct GoMacro {}
 extension GoMacro: CodeItemMacro {
     static func expansion(
         of node: some FreestandingMacroExpansionSyntax,
-        in context: some MacroExpansionContext
+        in context: some MacroExpansionContext,
     ) -> [CodeBlockItemSyntax] {
         switch node.macroName.text {
         case "go":

--- a/Tests/HTMLEntitiesTests/HTMLEntitiesTests.swift
+++ b/Tests/HTMLEntitiesTests/HTMLEntitiesTests.swift
@@ -12,7 +12,7 @@ func namedCharRef() throws {
     let dict = try JSONDecoder()
         .decode(
             [String: Entry].self,
-            from: Data(contentsOf: #require(Bundle.module.url(forResource: "entities", withExtension: "json")))
+            from: Data(contentsOf: #require(Bundle.module.url(forResource: "entities", withExtension: "json"))),
         )
 
     for (key, value) in dict {

--- a/Tests/TokenizerTests/HTML5LibTestsParser.swift
+++ b/Tests/TokenizerTests/HTML5LibTestsParser.swift
@@ -21,7 +21,7 @@ struct TestFileEntry {
                 input: self.input,
                 tokens: try self.output.flatMap { try $0.into() } + [.eof],
                 initialState: .init(state),
-                errors: self.errors
+                errors: self.errors,
             )
         }
     }
@@ -183,7 +183,7 @@ struct TestDOCTYPE: Equatable, Sendable {
         name: consuming Str? = nil,
         publicID: consuming Str? = nil,
         systemID: consuming Str? = nil,
-        forceQuirks: Bool = false
+        forceQuirks: Bool = false,
     ) {
         self.name = name
         self.publicID = publicID

--- a/Tests/TreeConstructorTests/TreeConstructorTests.swift
+++ b/Tests/TreeConstructorTests/TreeConstructorTests.swift
@@ -13,7 +13,7 @@ func testDOM() {
     // constructor.process(.tag(.init(name: "a", kind: .end)))
     let expected = Node(
         value: .document,
-        childNodes: []
+        childNodes: [],
     )
     #expect(constructor.sink.document == expected)
 }


### PR DESCRIPTION
Now, we can use [SE-0439](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0439-trailing-comma-lists.md).
