### PR TITLE
feat(TreeConstructor): make `TreeConstructor` sendable when possible

### DIFF
--- a/Sources/TreeConstructor/TreeConstructor.swift
+++ b/Sources/TreeConstructor/TreeConstructor.swift
@@ -183,3 +183,5 @@ extension TreeConstructor: TokenSink {
         } while true
     }
 }
+
+extension TreeConstructor: Sendable where Sink: Sendable {}


### PR DESCRIPTION
We have already done the same thing for `Tokenizer` and there is no reason not to do this.
