### PR TITLE
build: organize Swift settings

### DIFF
--- a/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
+++ b/Benchmarks/Benchmarks/MyBenchmark/MyBenchmark.swift
@@ -15,7 +15,11 @@ extension TestSink: TokenSink {
 
 private func runBench(_ name: String, configuration conf: Benchmark.Configuration) {
     // swift-format-ignore: NeverUseForceTry, NeverForceUnwrap
-    let html = try! String(contentsOf: Bundle.module.url(forResource: name, withExtension: "html")!).unicodeScalars
+    let html = try! String(
+        contentsOf: Bundle.module.url(forResource: name, withExtension: "html")!,
+        encoding: .utf8,
+    )
+    .unicodeScalars
     let input = ArraySlice(consume html)
     Benchmark(name, configuration: conf) { benchmark in
         for _ in benchmark.scaledIterations {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 
@@ -21,7 +21,9 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
+                .treatAllWarnings(as: .error),
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
+                .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,13 @@
 import CompilerPluginSupport
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+]
+
 let package = Package(
     name: "zyphy",
     platforms: [
@@ -29,15 +36,9 @@ let package = Package(
                 "HTMLEntities",
                 .product(name: "DequeModule", package: "swift-collections"),
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
+            swiftSettings: swiftSettings + [
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
                 .enableExperimentalFeature("CodeItemMacros"),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
             ],
         ),
         .target(
@@ -45,14 +46,8 @@ let package = Package(
             dependencies: [
                 "Tokenizer"
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
+            swiftSettings: swiftSettings + [
+                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ],
         ),
         .macro(
@@ -61,32 +56,18 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
         .target(
             name: "HTMLEntities",
             dependencies: [
                 "Str"
             ],
-            swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
         .target(
             name: "Str",
-            swiftSettings: [
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
         .testTarget(
             name: "TokenizerTests",
@@ -121,12 +102,7 @@ let package = Package(
                 .process("Resources/html5lib-tests/tokenizer/escapeFlag.test"),
                 .process("Resources/html5lib-tests/tokenizer/domjs.test"),
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
         .testTarget(
             name: "HTMLEntitiesTests",
@@ -136,24 +112,14 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
         .testTarget(
             name: "TreeBuilderTests",
             dependencies: [
                 "TreeBuilder"
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Werror", "ExistentialAny"]),
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
-                .enableUpcomingFeature("MemberImportVisibility"),
-            ],
+            swiftSettings: swiftSettings,
         ),
     ],
 )


### PR DESCRIPTION
Also, I added `.treatAllWarnings(as: .error)`. This flag helps me permanently eliminate warnings.