### PR TITLE
build: remove `InlineAlways` feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let swiftTestSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
-    .enableExperimentalFeature("InlineAlways"),
 ]
 
 let package = Package(


### PR DESCRIPTION
`InlineAlways` has been approved. So we don't need the feature flag.