### PR TITLE
refactor(Tokenizer): remove stored `charRefTokenizer` property

### DIFF
--- a/Sources/Tokenizer/Optional+take.swift
+++ b/Sources/Tokenizer/Optional+take.swift
@@ -1,8 +1,0 @@
-extension Optional where Wrapped: ~Copyable {
-    @inline(always)
-    mutating func take() -> Self {
-        let value = consume self
-        self = nil
-        return consume value
-    }
-}

--- a/Sources/Tokenizer/macros.swift
+++ b/Sources/Tokenizer/macros.swift
@@ -53,7 +53,6 @@ import Str
 @freestanding(codeItem) macro goEmitDOCTYPEAndEOF() = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) macro goEmitForceQuirksDOCTYPEAndEOF() = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) macro goEmitNewForceQuirksDOCTYPEAndEOF() = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
-@freestanding(codeItem) macro goConsumeCharRef(inAttr: Bool) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) macro go(error: ParseError, _: ParseError, to: State) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) macro go(error: ParseError, _: ParseError, createComment: Str, to: State) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")
 @freestanding(codeItem) macro go(error: ParseError, _: ParseError, appendComment: Str, to: State) = #externalMacro(module: "TokenizerMacros", type: "GoMacro")

--- a/Sources/TokenizerMacros/GoMacro.swift
+++ b/Sources/TokenizerMacros/GoMacro.swift
@@ -179,8 +179,6 @@ extension GoMacro: CodeItemMacro {
                 "self.emitEOF()",
                 "return .suspend",
             ]
-        case "goConsumeCharRef":
-            return ["self.consumeCharRef(\(node.arguments))", "return .continue"]
         case let name:
             preconditionFailure("not supported: \(name)")
         }


### PR DESCRIPTION
This might improve performance. Let's benchmark it.