### PR TITLE
ci: remove `--parallel` from `swift test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: ./scripts/ci-install-swift.sh
       - run: swift --version
       - run: swift build --build-tests --disable-xctest --enable-code-coverage
-      - run: swift test --skip-build --disable-xctest --enable-code-coverage --parallel
+      - run: swift test --skip-build --disable-xctest --enable-code-coverage
       - name: llvm-cov report
         id: report
         run: |


### PR DESCRIPTION
In swift-testing, `swift test` runs tests in parallel. So `--parallel` is not needed.