### PR TITLE
perf: make internal function definitions available for clients

### DIFF
--- a/Sources/Tokenizer/BufferQueue.swift
+++ b/Sources/Tokenizer/BufferQueue.swift
@@ -27,6 +27,7 @@ public struct BufferQueue: ~Copyable, Sendable {
     }
 
     @inline(always)
+    @export(implementation)
     mutating func pop(except s: consuming SmallCharSet) -> PopResult? {
         guard !self.buffers.isEmpty else { return nil }
         defer { if self.buffers[0].isEmpty { self.buffers.removeFirst() } }

--- a/Sources/Tokenizer/DOCTYPE.swift
+++ b/Sources/Tokenizer/DOCTYPE.swift
@@ -19,6 +19,7 @@ public struct DOCTYPE: ~Copyable, Sendable {
     }
 
     @inline(always)
+    @export(implementation)
     borrowing func clone() -> Self {
         .init(
             name: self.name,

--- a/Sources/Tokenizer/PopResult.swift
+++ b/Sources/Tokenizer/PopResult.swift
@@ -1,5 +1,6 @@
-import Str
+public import Str
 
+@usableFromInline
 enum PopResult: ~Copyable {
     case known(Char)
     case others(StrSlice)

--- a/Sources/Tokenizer/SmallCharSet.swift
+++ b/Sources/Tokenizer/SmallCharSet.swift
@@ -1,15 +1,19 @@
-import Str
+public import Str
 
+@usableFromInline
 struct SmallCharSet {
+    @usableFromInline
     var bits: UInt64
 
     @inline(always)
+    @export(implementation)
     func contains(_ c: Char) -> Bool {
         self.bits & 1 << c.value != 0
     }
 }
 
 extension SmallCharSet: ExpressibleByArrayLiteral {
+    @usableFromInline
     init(arrayLiteral elements: Char...) {
         self.bits = elements.lazy.map { 1 << $0.value }.reduce(0, |)
     }

--- a/Sources/Tokenizer/Utils.swift
+++ b/Sources/Tokenizer/Utils.swift
@@ -1,6 +1,7 @@
-import Str
+public import Str
 
 @inline(always)
+@export(implementation)
 func lowerASCIIOrNil(_ c: consuming Char) -> Char? {
     switch c {
     case let c where "A"..."Z" ~= c: .init(.init(UInt8(c.value) &+ 0x20))
@@ -10,6 +11,7 @@ func lowerASCIIOrNil(_ c: consuming Char) -> Char? {
 }
 
 @inline(always)
+@export(implementation)
 func lowerASCII(_ c: consuming Char) -> Char {
     switch c {
     case let c where "A"..."Z" ~= c: .init(.init(UInt8(c.value) &+ 0x20))


### PR DESCRIPTION
This PR fixes the performance regression in ab674676e8db67ecde9411d1b9387c2460b15f9a.