### PR TITLE
build(benchmark): bump package-benchmark to 1.31.0

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-benchmark",
       "state" : {
-        "revision" : "a1075611342d4b164bf6e977edb02a3db4434afd",
-        "version" : "1.29.11"
+        "revision" : "69bde19b29c4365e5a23179add8df4f93c76566c",
+        "version" : "1.31.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
+        "version" : "1.5.1"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ swift test --disable-xctest
 ## Benchmarking
 
 ```shell
-BENCHMARK_DISABLE_JEMALLOC=true swift package --package-path Benchmarks benchmark
+swift package --package-path Benchmarks benchmark
 ```
 
 For more details, please see https://github.com/ordo-one/package-benchmark.


### PR DESCRIPTION
- https://github.com/ordo-one/package-benchmark/releases/tag/1.30.0
- https://github.com/ordo-one/package-benchmark/releases/tag/1.31.0