### PR TITLE
build(benchmark): remove jemalloc dependency

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a9e0344c86b29040fb3618a32f32a87e85b6e965c5b376520a030f9c997d43f8",
+  "originHash" : "94691f9d26597f207444dbb5839a5263cab281f124c4bd2ee8e17d20416539cd",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "69bde19b29c4365e5a23179add8df4f93c76566c",
         "version" : "1.31.0"
-      }
-    },
-    {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc.git",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v26), .iOS(.v26)],
     dependencies: [
         .package(name: "zyphy", path: ".."),
-        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.23.5"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.30.0", traits: []),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Our tests are only for speed, not for memory. Therefore, we don't need jemalloc.

refs: https://swiftpackageindex.com/ordo-one/package-benchmark/1.30.0/documentation/benchmark/gettingstarted