### PR TITLE
ci: fix benchmark jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,19 +121,19 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           clean: false
-      - run: swift package --package-path Benchmarks benchmark baseline update base --no-progress --quiet
+      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update base --no-progress --quiet
       - name: swift package benchmark baseline check
         id: check
         run: |
           set +e
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks --build-system native benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: swift package benchmark baseline compare
         id: compare
         run: |
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks --build-system native benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: Create summary text
         id: summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             Benchmarks/.build
           key: ${{ runner.os }}-bench-swiftpm-${{ hashFiles('Benchmarks/Package.resolved') }}
           restore-keys: ${{ runner.os }}-bench-swiftpm-
-      - run: swift package --package-path Benchmarks benchmark baseline update pull_request --no-progress --quiet
+      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update pull_request --no-progress --quiet
       - name: Switch to branch '${{ github.event.pull_request.base.ref }}'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ swift test --disable-xctest
 ## Benchmarking
 
 ```shell
-swift package --package-path Benchmarks benchmark
+swift package --package-path Benchmarks --build-system native benchmark
 ```
 
 For more details, please see https://github.com/ordo-one/package-benchmark.


### PR DESCRIPTION
The latest SwiftPM has changed its output directory structure. That broke package-benchmark's build system in its command plugin.

I've decided to use the legacy build system to fix that for now.