### PR TITLE
revert: revert `--build-system native` on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           restore-keys: ${{ runner.os }}-swiftpm-
       - run: ./scripts/ci-install-swift.sh
       - run: swift --version
-      - run: swift test --disable-xctest --build-system native
+      - run: swift test --disable-xctest
   comment-test:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux


### PR DESCRIPTION
On the latest toolchain, this workaround is no longer needed.