### PR TITLE
ci: fix dependabot for gitsubmodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     commit-message:
       prefix: "ci"
   - package-ecosystem: "gitsubmodule"
-    directory: "/Tests"
+    directory: "/"
     schedule:
       interval: "weekly"
     assignees:


### PR DESCRIPTION
fixes #234

`.gitmodules` is in the project root directory.