### PR TITLE
chore: update .swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -2,6 +2,7 @@
   "fileScopedDeclarationPrivacy" : {
     "accessLevel" : "private"
   },
+  "indentBlankLines" : false,
   "indentConditionalCompilationBlocks" : true,
   "indentSwitchCaseLabels" : false,
   "indentation" : {
@@ -12,13 +13,18 @@
   "lineBreakBeforeEachArgument" : true,
   "lineBreakBeforeEachGenericRequirement" : true,
   "lineBreakBetweenDeclarationAttributes" : true,
-  "lineLength" : 120,
+  "lineLength" : 121,
   "maximumBlankLines" : 1,
   "multiElementCollectionTrailingCommas" : true,
+  "multilineTrailingCommaBehavior" : "alwaysUsed",
   "noAssignmentInExpressions" : {
     "allowedFunctions" : [
       "XCTAssertNoThrow"
     ]
+  },
+  "orderedImports" : {
+    "includeConditionalImports" : false,
+    "shouldGroupImports" : true
   },
   "prioritizeKeepingFunctionOutputTogether" : true,
   "reflowMultilineStringLiterals" : "never",


### PR DESCRIPTION
I updated .swift-format following Swift 6.4's changes.

The reason why I changed `lineLength` from `120` to `121` is https://github.com/swiftlang/swift-format/issues/1219.