### PR TITLE
chore: set `lineLength` back to 120

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -13,7 +13,7 @@
   "lineBreakBeforeEachArgument" : true,
   "lineBreakBeforeEachGenericRequirement" : true,
   "lineBreakBetweenDeclarationAttributes" : true,
-  "lineLength" : 121,
+  "lineLength" : 120,
   "maximumBlankLines" : 1,
   "multiElementCollectionTrailingCommas" : true,
   "multilineTrailingCommaBehavior" : "alwaysUsed",


### PR DESCRIPTION
This can be merged after https://github.com/swiftlang/swift-format/issues/1219 is resolved.