### PR TITLE
Update Swift settings

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
+                .strictMemorySafety(),
             ],
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "benchmark")

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -26,6 +26,9 @@ let package = Package(
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
                 .enableUpcomingFeature("MemberImportVisibility"),
+                .enableUpcomingFeature("InferIsolatedConformances"),
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                .enableUpcomingFeature("ImmutableWeakCaptures"),
                 .strictMemorySafety(),
             ],
             plugins: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
-    .enableExperimentalFeature("InlineAlways"),
     .strictMemorySafety(),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableExperimentalFeature("InlineAlways"),
+    .strictMemorySafety(),
 ]
 
 let swiftTestSettings: [SwiftSetting] = [
@@ -17,6 +18,7 @@ let swiftTestSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
+    .strictMemorySafety(),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
     .strictMemorySafety(),
 ]
 
@@ -17,6 +20,9 @@ let swiftTestSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
     .strictMemorySafety(),
 ]
 


### PR DESCRIPTION
- Removed a feature flag that no longer needed
- Enabled strict memory safety
- Added upcoming feature flags that newly added to the latest compiler