### PR TITLE
revert: build(benchmark): bump benchmark to 1.35.0

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5ec5e340f738d7fbd5bcf9b72927fb023448bf38a81f2b2066137c4a6c5ee4cb",
+  "originHash" : "4a41de688a2ea7ae987a7b073e0a6d0e2fdbff3bc4d6fcfeebb2ab37917f5d61",
   "pins" : [
     {
       "identity" : "benchmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/benchmark",
       "state" : {
-        "revision" : "4b9ef5663e9c270419351a20392bf77b007f37f6",
-        "version" : "1.35.0"
+        "revision" : "595d8db7d9d612ecf256ebf659c20aeec338c5ca",
+        "version" : "1.34.1"
       }
     },
     {
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "c2e1210df04b4fff47e53f2f9dad9cc45ae15d63",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "malloc-interposer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/malloc-interposer.git",
-      "state" : {
-        "revision" : "8ce418ba70e494577fdc046be8c8ddb5216f16e5",
-        "version" : "1.3.1"
       }
     },
     {
@@ -42,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
-        "version" : "1.3.1"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v26), .iOS(.v26)],
     dependencies: [
         .package(name: "zyphy", path: ".."),
-        .package(url: "https://github.com/ordo-one/benchmark", from: "1.35.0"),
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.30.0", traits: []),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
This reverts commit 94fcbcdb7813fc245dd7a46f0db8a1d490e9c2f1.

Building ordo-one/benchmark 1.35.0 appears failing on Linux.

- https://github.com/kkebo/zyphy/actions/runs/28260241288/job/83734882366?pr=255
- https://github.com/kkebo/zyphy/actions/runs/28267359099/job/83757565730
- https://github.com/kkebo/zyphy/actions/runs/28261934502/job/83739808343?pr=249

```
error: Swift package target 'SwiftRuntimeInterposerC' is linked as a static library by 'BenchmarkTool-product' and 'SwiftRuntimeInterposerC-product', but cannot be built dynamically because there is a package product with the same name.
error: Build failed
error: fatalError
```

It may be that the CI run for PR #251 was successful because of the cache.