### PR TITLE
ci: use native build system for benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
             Benchmarks/.build
           key: ${{ runner.os }}-bench-swiftpm-${{ hashFiles('Benchmarks/Package.resolved') }}
           restore-keys: ${{ runner.os }}-bench-swiftpm-
-      - run: swift package --package-path Benchmarks benchmark --no-progress --format markdown >> "$GITHUB_STEP_SUMMARY"
+      - run: swift package --package-path Benchmarks --build-system native benchmark --no-progress --format markdown >> "$GITHUB_STEP_SUMMARY"
   benchmark:
     if: ${{ github.event_name == 'pull_request' }}
     needs: test-linux
@@ -137,25 +137,25 @@ jobs:
             Benchmarks/.build
           key: ${{ runner.os }}-bench-swiftpm-${{ hashFiles('Benchmarks/Package.resolved') }}
           restore-keys: ${{ runner.os }}-bench-swiftpm-
-      - run: swift package --package-path Benchmarks benchmark baseline update pull_request --no-progress --quiet
+      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update pull_request --no-progress --quiet
       - name: Switch to branch '${{ github.event.pull_request.base.ref }}'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           clean: false
-      - run: swift package --package-path Benchmarks benchmark baseline update base --no-progress --quiet
+      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update base --no-progress --quiet
       - name: swift package benchmark baseline check
         id: check
         run: |
           set +e
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks --build-system native benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: swift package benchmark baseline compare
         id: compare
         run: |
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks --build-system native benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: Create summary text
         id: summary

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ swift test --disable-xctest
 ## Benchmarking
 
 ```shell
-swift package --package-path Benchmarks benchmark
+swift package --package-path Benchmarks --build-system native benchmark
 ```
 
 For more details, please see https://github.com/ordo-one/package-benchmark.


### PR DESCRIPTION
Building ordo-one/benchmark 1.35.0 appears to be failing on Linux.

- https://github.com/kkebo/zyphy/actions/runs/28260241288/job/83734882366?pr=255
- https://github.com/kkebo/zyphy/actions/runs/28267359099/job/83757565730
- https://github.com/kkebo/zyphy/actions/runs/28261934502/job/83739808343?pr=249

```
error: Swift package target 'SwiftRuntimeInterposerC' is linked as a static library by 'BenchmarkTool-product' and 'SwiftRuntimeInterposerC-product', but cannot be built dynamically because there is a package product with the same name.
error: Build failed
error: fatalError
```

This PR tries to fix that.