### PR TITLE
ci: introduce octocov again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ defaults:
 jobs:
   test-linux:
     runs-on: ubuntu-24.04-arm
-    outputs:
-      SUMMARY: ${{ steps.summary.outputs.SUMMARY }}
     permissions:
       contents: read
     steps:
@@ -33,30 +31,11 @@ jobs:
       - run: swift --version
       - run: swift build --explicit-target-dependency-import-check error --build-tests --disable-xctest --enable-code-coverage
       - run: swift test --skip-build --disable-xctest --enable-code-coverage
-      - name: llvm-cov report
-        id: report
-        run: |
-          echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          llvm-cov report .build/out/Products/Debug-linux/TreeBuilderTests.so --instr-profile=.build/out/Products/Debug-linux/codecov/default.profdata --ignore-filename-regex=".build|Tests|TokenizerMacros" --show-region-summary=false --show-branch-summary=false >> "$GITHUB_OUTPUT"
-          echo 'EOF' >> "$GITHUB_OUTPUT"
-      - name: Create summary text
-        id: summary
-        env:
-          REPORT_OUTPUT: ${{ steps.report.outputs.OUTPUT }}
-        run: |
-          echo 'SUMMARY<<EOF' >> "$GITHUB_OUTPUT"
-          echo '## Coverage Summary' >> "$GITHUB_OUTPUT"
-          echo >> "$GITHUB_OUTPUT"
-          echo "$(date)" >> "$GITHUB_OUTPUT"
-          echo >> "$GITHUB_OUTPUT"
-          echo '```' >> "$GITHUB_OUTPUT"
-          echo "$REPORT_OUTPUT" >> "$GITHUB_OUTPUT"
-          echo '```' >> "$GITHUB_OUTPUT"
-          echo 'EOF' >> "$GITHUB_OUTPUT"
-      - name: Create a job summary
-        env:
-          SUMMARY: ${{ steps.summary.outputs.SUMMARY }}
-        run: echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+      - run: llvm-cov export --format=lcov .build/out/Products/Debug-linux/TreeBuilderTests.so --instr-profile=.build/out/Products/Debug-linux/codecov/default.profdata --ignore-filename-regex=".build|Tests|TokenizerMacros" > coverage_report.lcov
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-report-lcov
+          path: coverage_report.lcov
   test-macos:
     runs-on: macos-26
     permissions:
@@ -78,20 +57,19 @@ jobs:
       - run: swift --version
       - run: swift test --explicit-target-dependency-import-check error --disable-xctest
   comment-test:
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     permissions:
+      contents: read
       pull-requests: write
+      actions: write
     steps:
-      - name: Comment PR
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          SUMMARY: ${{ needs.test-linux.outputs.SUMMARY }}
-        run: gh pr comment "$PR_NUMBER" --body "$SUMMARY"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: coverage-report-lcov
+      - uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9  # v1.5.1
   lint:
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,22 @@
+coverage:
+  paths:
+    - coverage_report.lcov
+  badge:
+    path: coverage.svg
+push:
+  if: is_default_branch
+  message: 'docs: update by octocov [skip ci]'
+testExecutionTime:
+  if: false
+comment:
+  if: is_pull_request
+  updatePrevious: true
+summary:
+  if: true
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zyphy
 
+![coverage](coverage.svg)
+
 Zyphy is (or will be) a fast web browser engine written in Swift.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Although I previously replaced octocov with my basic workflow due to Issue #68, octocov 0.75.10 has fixed it. It's time to go back to octocov.