### PR TITLE
ci: fix permissions for the octocov job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       actions: write
     steps:


### PR DESCRIPTION
This PR fixes https://github.com/kkebo/zyphy/actions/runs/29740292275/job/88345890079.