### PR TITLE
build(benchmark): update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             Benchmarks/.build
           key: ${{ runner.os }}-bench-swiftpm-${{ hashFiles('Benchmarks/Package.resolved') }}
           restore-keys: ${{ runner.os }}-bench-swiftpm-
-      - run: swift package --package-path Benchmarks --build-system native benchmark --no-progress --format markdown >> "$GITHUB_STEP_SUMMARY"
+      - run: swift package --package-path Benchmarks benchmark --no-progress --format markdown >> "$GITHUB_STEP_SUMMARY"
   benchmark:
     if: ${{ github.event_name == 'pull_request' }}
     needs: test-linux
@@ -115,25 +115,25 @@ jobs:
             Benchmarks/.build
           key: ${{ runner.os }}-bench-swiftpm-${{ hashFiles('Benchmarks/Package.resolved') }}
           restore-keys: ${{ runner.os }}-bench-swiftpm-
-      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update pull_request --no-progress --quiet
+      - run: swift package --package-path Benchmarks benchmark baseline update pull_request --no-progress --quiet
       - name: Switch to branch '${{ github.event.pull_request.base.ref }}'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           clean: false
-      - run: swift package --package-path Benchmarks --build-system native benchmark baseline update base --no-progress --quiet
+      - run: swift package --package-path Benchmarks benchmark baseline update base --no-progress --quiet
       - name: swift package benchmark baseline check
         id: check
         run: |
           set +e
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks --build-system native benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks benchmark baseline check base pull_request --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: swift package benchmark baseline compare
         id: compare
         run: |
           echo 'OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
-          swift package --package-path Benchmarks --build-system native benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
+          swift package --package-path Benchmarks benchmark baseline compare base pull_request --no-progress --quiet --format markdown >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: Create summary text
         id: summary

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5ec5e340f738d7fbd5bcf9b72927fb023448bf38a81f2b2066137c4a6c5ee4cb",
+  "originHash" : "7286426ac9118e4ed8eb4406695dec24972963467c07e30660b18c00e6ec06bd",
   "pins" : [
     {
       "identity" : "benchmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/benchmark",
       "state" : {
-        "revision" : "4b9ef5663e9c270419351a20392bf77b007f37f6",
-        "version" : "1.35.0"
+        "revision" : "4281e1b3061f1e72de284715977cf50dda001c89",
+        "version" : "1.36.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/swift-runtime-interposer.git",
       "state" : {
-        "revision" : "7fd519fa3947bc8d29495f60fc8b6580ec361b5d",
-        "version" : "1.0.0"
+        "revision" : "7631b4611a446868f1ecc94fde10b4b14c41f711",
+        "version" : "2.0.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v26), .iOS(.v26)],
     dependencies: [
         .package(name: "zyphy", path: ".."),
-        .package(url: "https://github.com/ordo-one/benchmark", from: "1.35.0"),
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.36.0"),
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ swift test --disable-xctest
 ## Benchmarking
 
 ```shell
-swift package --package-path Benchmarks --build-system native benchmark
+swift package --package-path Benchmarks benchmark
 ```
 
 For more details, please see https://github.com/ordo-one/package-benchmark.


### PR DESCRIPTION
https://github.com/ordo-one/benchmark/releases/tag/1.36.0

It seems that the `--build-system native` flag is no longer needed.